### PR TITLE
3/3 PR: Adding fast_layer_fidelity script

### DIFF
--- a/qiskit_device_benchmarking/verification/Readme.md
+++ b/qiskit_device_benchmarking/verification/Readme.md
@@ -17,4 +17,11 @@ Mirror QV circuits which are all-to-all and HE (hardware-efficient) Mirror QV ci
 
 The output can be turned into plots with `bench_analyze.py`, e.g. `python bench_analyze.py -f MQV_2024-04-27_06_19_32.yaml -v max --plot` will product a plot of all the maximum results over the sets from the listed file. Plots are generated as pdf.
 
+Similarly, the file `fast_layer_fidelity.py` is a command line invocation to run a single layer fidelity experiment on specified device(s) `python fast_layer_fidelity.py`. The qubit chain selected for this is the reported 100Q on qiskit for each device(s). This file also requires a config file (default is `config.yaml`) of the form (unless overwritten by command line arguments)
+```
+hgp: X/X/X
+backends: [ibm_fez]
+channel: 'ibm_quantum' or 'imb_cloud'
+```
+
 Circuits are based on the code written for https://arxiv.org/abs/2303.02108 which was based on the earlier work by Proctor et al [Phys. Rev. Lett. 129, 150502 (2022)](https://doi.org/10.48550/arXiv.2112.09853). 

--- a/qiskit_device_benchmarking/verification/fast_layer_fidelity.py
+++ b/qiskit_device_benchmarking/verification/fast_layer_fidelity.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Fast Layer Fidelity on the reported 100Q qiskit chain
+"""
+
+import argparse
+import numpy as np
+import matplotlib.pyplot as plt
+import pandas as pd
+from typing import Dict, List, Tuple
+import datetime
+import os 
+
+from qiskit_ibm_runtime import QiskitRuntimeService
+from qiskit_ibm_runtime.ibm_backend import IBMBackend
+from qiskit_experiments.framework.experiment_data import ExperimentData
+from qiskit_experiments.library.randomized_benchmarking import LayerFidelity
+from qiskit.visualization import plot_gate_map
+from qiskit.transpiler import CouplingMap
+
+import qiskit_device_benchmarking.utilities.layer_fidelity_utils as lfu
+import qiskit_device_benchmarking.utilities.graph_utils as gu
+import qiskit_device_benchmarking.utilities.file_utils as fu
+
+
+def run_fast_lf(backends: List[str],
+    nseeds: int,
+    seed: int,
+    cliff_lengths: List[int],
+    nshots: int,
+    act_name: str,
+    hgp: str):
+    
+    # load the service
+    print('Loading service')
+    service = QiskitRuntimeService(name=act_name)
+    
+    for backend_name in backends:    
+        # Make experiment folder 
+        time = datetime.datetime.now().strftime('%Y-%m-%d-%H.%M.%S')
+        directory = f"{time}_layer_fidelity"
+        path = os.path.join('', directory)
+        print(f'Creating folder {directory}')
+        os.mkdir(path)
+        print(f'Changing directory to {directory}')
+        os.chdir(path)
+        
+        # Get the real backend
+        print(f'Getting backend {backend_name}')
+        backend = service.backend(backend_name, instance=hgp)
+
+        # Get 100Q chain from qiskit
+        qchain = backend.properties().general_qlists[0]['qubits']
+        print(f'100Q chain for {backend_name} is: ', qchain)
+
+        # Run LF
+        print(f'Running LF on {backend_name}')
+        exp_data = lfu.run_lf_chain(
+            chain=qchain,
+            backend=backend,
+            nseeds=nseeds,
+            seed=seed,
+            cliff_lengths=cliff_lengths,
+            nshots=nshots)
+
+        # Fit 2Q experiment data
+        print(f'Retrieving experiment results from {backend_name}')
+        exp_data.block_for_results()
+
+        # Get LF and EPLG data per length
+        results_per_length = lfu.reconstruct_lf_per_length(exp_data, qchain, backend)
+        results_per_length.to_csv(f'{backend_name}_lf_eplg_data.csv', float_format='%.15f')
+
+        # Retrieve raw and fitted RB data
+        rb_data_df = lfu.get_rb_data(exp_data)
+        print(f'Saving 2Q data from {backend_name}')
+        rb_data_df.to_csv(f'{backend_name}_full_rb_data.csv', float_format='%.15f')
+
+        # Plot LF and EPLG data
+        print(f'Making plots for {backend_name}')
+        lfu.make_lf_eplg_plots(
+            backend=backend,
+            exp_data=exp_data,
+            chain=qchain,
+            machine=backend_name
+        )
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description = 'Run fast layer fidelity '
+                                     + 'on reported qikist chain. Specify a config '
+                                     +' yaml and override settings on the command line')
+    parser.add_argument('-c', '--config', help='config file name', 
+                        default='config.yaml')
+    parser.add_argument('-b', '--backend', help='Specify backend and override '
+                        + 'backend_group')
+    parser.add_argument('-bg', '--backend_group', 
+                        help='specify backend group in config file', 
+                        default='backends')
+    parser.add_argument('--hgp', help='specify hgp / qiskit instance', default ='')
+    parser.add_argument('--name', help='Account name', default='')
+    parser.add_argument('--nseeds', help='number of seeds', default=6)
+    parser.add_argument('--seed', help='seed to use', default=42)
+    parser.add_argument('--nshots', help='number of shots', default=200)
+    parser.add_argument(
+        '--cliff_lengths',
+        help='list of clifford lenghts [...]',
+        default=[1, 10, 20, 30, 40, 60, 80, 100, 150, 200, 400],
+    )
+    args = parser.parse_args()
+    
+    #import from config
+    config_dict = fu.import_yaml(args.config)
+    print('Config File Found')
+    print(config_dict)
+    
+    #override from the command line
+    if args.backend is not None:
+        backends = [args.backend]
+    else:
+        backends = config_dict[args.backend_group]  
+    if args.hgp is not None:
+        hgp = args.hgp
+    else:
+        hgp = config_dict['hgp']   
+    # set default values unless otherwise instructed on config_dict 
+    if 'nseeds' in config_dict.keys():
+        nseeds = config_dict['nseeds']
+    else:
+        nseeds = args.nseeds   
+    if 'seed' in config_dict.keys():
+        seed = config_dict['seed']
+    else:
+        seed = args.seed   
+    if 'cliff_lengths' in config_dict.keys():
+        cliff_lengths = config_dict['cliff_lengths']
+    else:
+        cliff_lengths = args.cliff_lengths   
+    if 'nshots' in config_dict.keys():
+        nshots = config_dict['nshots']
+    else:
+        nshots = args.nshots
+    if 'act_name' in config_dict.keys():
+        act_name = config_dict['act_name']
+    else:
+        act_name = args.name
+    
+    # Run fast layer fidelity on the list of backends
+    print('Running fast layer fidelity on backend(s)')
+    run_fast_lf(backends, nseeds, seed, cliff_lengths, nshots, act_name, hgp)

--- a/qiskit_device_benchmarking/verification/fast_layer_fidelity.py
+++ b/qiskit_device_benchmarking/verification/fast_layer_fidelity.py
@@ -43,18 +43,28 @@ def run_fast_lf(backends: List[str],
     act_name: str,
     hgp: str):
     
-    # load the service
+    # Make a general experiment folder 
+    parent_path = os.path.join(os.getcwd(), 'layer_fidelity')
+    try:
+        print(f'Creating folder {parent_path}')
+        os.mkdir(parent_path)
+    except:
+        pass
+    print(f'Changing directory to {parent_path}')
+    os.chdir(parent_path)
+    
+    # Load the service
     print('Loading service')
     service = QiskitRuntimeService(name=act_name)
     
     for backend_name in backends:    
-        # Make experiment folder 
+        # Make an experiment folder each backend
         time = datetime.datetime.now().strftime('%Y-%m-%d-%H.%M.%S')
         directory = f"{time}_{backend_name}_layer_fidelity"
-        path = os.path.join('', directory)
-        print(f'Creating folder {directory}')
+        path = os.path.join(parent_path, directory)
+        print(f'Creating folder {path}')
         os.mkdir(path)
-        print(f'Changing directory to {directory}')
+        print(f'Changing directory to {path}')
         os.chdir(path)
         
         # Get the real backend

--- a/qiskit_device_benchmarking/verification/fast_layer_fidelity.py
+++ b/qiskit_device_benchmarking/verification/fast_layer_fidelity.py
@@ -50,7 +50,7 @@ def run_fast_lf(backends: List[str],
     for backend_name in backends:    
         # Make experiment folder 
         time = datetime.datetime.now().strftime('%Y-%m-%d-%H.%M.%S')
-        directory = f"{time}_layer_fidelity"
+        directory = f"{time}_{backend_name}_layer_fidelity"
         path = os.path.join('', directory)
         print(f'Creating folder {directory}')
         os.mkdir(path)


### PR DESCRIPTION
File fast_layer_fidelity.py is a command line invocation to run a single layer fidelity experiment on a specified list of device(s). The qubit chain selected for this is the reported 100Q on qiskit for each device(s). This file requires a config file (default is config.yaml) of the form (unless overwritten by command line arguments)

hgp: X/X/X
backends: [ibm_fez]
channel: 'ibm_quantum' or 'imb_cloud'