### PR TITLE
Mirror test: Reduce number of twirls in learning phase to 50.

### DIFF
--- a/qiskit_device_benchmarking/mirror_test/mirror_test.py
+++ b/qiskit_device_benchmarking/mirror_test/mirror_test.py
@@ -91,7 +91,7 @@ def submit_mirror_test(backend: IBMBackend,
         options.resilience.layer_noise_model = noise_model
     else:
         options.resilience.layer_noise_learning.shots_per_randomization = 64
-        options.resilience.layer_noise_learning.num_randomizations = 1000
+        options.resilience.layer_noise_learning.num_randomizations = 50
 
     # experimental options
     options.experimental = {


### PR DESCRIPTION
Turns out to be sufficient in the learning phase. Keeping 1,000 twirls in the mitigating phase.