### PR TITLE
Correct spelling; remove trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Qiskit Device Benchmarking
 
-*Qiskit Device Benchmarking* is a respository for code to run various device level benchmarks through Qiskit. The repository endevours to accomplish several goals, including, but not limited to:
+*Qiskit Device Benchmarking* is a repository for code to run various device level benchmarks through Qiskit. The repository endeavors to accomplish several goals, including, but not limited to:
 - Code examples for users to replicate reported benchmarking metrics through the Qiskit backend. These will likely be notebooks to run code in the [Qiskit Experiments](https://github.com/Qiskit-Extensions/qiskit-experiments) repo, but some of the code may reside here.
 - More in-depth benchmarking code that was discussed in papers and has not been integrated into Qiskit Experiments.
 - Fast circuit validation tests.
@@ -42,6 +42,6 @@ Please open a github issue or pull request if you would like to contribute.
 
 [Apache License 2.0](LICENSE.txt)
 
-# Acknowledgements
+# Acknowledgments
 
 Portions of the code in this repository was developed via sponsorship by the Army Research Office ``QCISS Program'' under Grant Number W911NF-21-1-0002.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - More in-depth benchmarking code that was discussed in papers and has not been integrated into Qiskit Experiments.
 - Fast circuit validation tests.
 
-The repository is not intended to define a benchmark standard. This code base is not guaranteed to be stable and may have breaking changes. 
+The repository is not intended to define a benchmark standard. This code base is not guaranteed to be stable and may have breaking changes.
 
 # Structure
 
@@ -44,4 +44,4 @@ Please open a github issue or pull request if you would like to contribute.
 
 # Acknowledgements
 
-Portions of the code in this repository was developed via sponsorship by the Army Research Office ``QCISS Program'' under Grant Number W911NF-21-1-0002. 
+Portions of the code in this repository was developed via sponsorship by the Army Research Office ``QCISS Program'' under Grant Number W911NF-21-1-0002.

--- a/qiskit_device_benchmarking/bench_code/bell/bell_experiment.py
+++ b/qiskit_device_benchmarking/bench_code/bell/bell_experiment.py
@@ -29,15 +29,15 @@ class CHSHExperiment(BaseExperiment):
         Raises:
             QiskitError: If any invalid argument is supplied.
         """
-        
-        
+
+
         super().__init__(physical_qubits,
                          analysis = CHSHAnalysis(),
                          backend = backend)
 
     def circuits(self) -> List[QuantumCircuit]:
         """Generate the list of circuits to be run."""
-        
+
         #Four circuits for this experiment
         #Assume the ideal basis for this inequality
         circuits = []
@@ -45,11 +45,11 @@ class CHSHExperiment(BaseExperiment):
             qc = QuantumCircuit(2)
             qc.h(0)
             qc.cx(0,1)
-            
+
             #rotate the 2nd qubit by pi/4 (optimal for the inequality)
             qc.rx(np.pi/4,1)
-            
-            #measure in Z, ZY, YZ, YY 
+
+            #measure in Z, ZY, YZ, YY
             if np.mod(i,2):
                 qc.sx(0)
             if np.mod(int(i/2),2):
@@ -67,7 +67,7 @@ class CHSHExperiment(BaseExperiment):
             shots = 300,
         )
         return options
-    
+
 
 class CHSHAnalysis(BaseAnalysis):
     """Custom analysis class template."""
@@ -84,7 +84,7 @@ class CHSHAnalysis(BaseAnalysis):
 
     def _estate(self, counts):
         #from a counts dictionary determine the correlation function E
-        
+
         shots = np.sum([counts[i] for i in counts])
         return (counts.get('11',0)+counts.get('00',0)-counts.get('10',0)-counts.get('01',0))/shots
 
@@ -95,16 +95,16 @@ class CHSHAnalysis(BaseAnalysis):
         """Run the analysis."""
 
         # Process the data here
-        
+
         res = experiment_data.data()
 
         aa = [1,-1,-1,-1]
         S = np.sum([aa[i]*self._estate(res[i]['counts']) for i in range(4)])
-        
+
         analysis_results = [
             AnalysisResultData(name="S", value=S)
         ]
-            
+
         return analysis_results, None
 
 
@@ -116,8 +116,8 @@ class BellExperiment(BaseExperiment):
                  cxnum=5,
                  backend = None):
         """Initialize the experiment."""
-        
-        
+
+
         physical_qubits = []
         for layer in layered_coupling_map:
             for pair in layer:
@@ -126,7 +126,7 @@ class BellExperiment(BaseExperiment):
                 if pair[1] not in physical_qubits:
                     physical_qubits.append(pair[1])
         physical_qubits = range(backend.configuration().num_qubits)
-        
+
         self.layered_coupling_map = layered_coupling_map
         self.cxnum = cxnum
         super().__init__(physical_qubits,
@@ -148,7 +148,7 @@ class BellExperiment(BaseExperiment):
             shots = 2048,
         )
         return options
-    
+
 
 class BellAnalysis(BaseAnalysis):
     """Custom analysis class template."""
@@ -173,7 +173,7 @@ class BellAnalysis(BaseAnalysis):
         from qiskit.quantum_info import hellinger_fidelity
         from qiskit.result import marginal_counts
         import pandas as pd
-        
+
         res = experiment_data.data()
 
         cxnum = res[0]['metadata']['cxnum']
@@ -181,7 +181,7 @@ class BellAnalysis(BaseAnalysis):
                 target = {'00': 0.5, '11': 0.5}
         else: # even number of CX should be an identity
                 target = {'00': 0.5, '01': 0.5}
-        
+
         fid = []; cmap=[]
         for datum in res:
             coupling_map = datum['metadata']['coupling_map']
@@ -191,18 +191,18 @@ class BellAnalysis(BaseAnalysis):
             for cr, val in tmp.items():
                 cmap.append([int(bit) for bit in cr.split('_')])
                 fid.append(hellinger_fidelity(val, target))
-        
+
         df = {'connection':cmap,'fidelity':fid}
         fidelity_data = pd.DataFrame(df).sort_values(by='connection')
-        
-        
+
+
         analysis_results = [
             AnalysisResultData(name="hellinger_fidelities", value=fidelity_data)
         ]
         figures = []
         if self.options.plot:
             figures.append(self._plot(fidelity_data))
-            
+
         return analysis_results, figures
 
     def _plot(self,data):
@@ -219,14 +219,14 @@ def flatten_bits(crs):
         bits=[int(cr[0]) for cr in crs]
         bits.extend([int(cr[1]) for cr in crs])
         return bits
-    
+
 def make_bell_circs(layered_coupling_map, conf, cxnum):
-    """ 
+    """
     run simultaneous bell test. simultaneous pairs are obtained from get_layered_coupling_map
-    We assume each cr ran only one time 
+    We assume each cr ran only one time
     (e.g. [[1_2, 3_4], [5_6, 7_8]] is okay, but [[1_2, 3_4], [1_2, 5_6, 7_8]] is not okay)
     """
-    
+
     from qiskit.transpiler import CouplingMap
 
 
@@ -240,7 +240,7 @@ def make_bell_circs(layered_coupling_map, conf, cxnum):
     circs=[]
 
     for coupling_map in layered_coupling_map:
-        bits=flatten_bits(coupling_map); 
+        bits=flatten_bits(coupling_map);
         nbits=len(bits)
 
         qc = QuantumCircuit(conf.n_qubits, nbits)
@@ -290,7 +290,7 @@ def make_bell_circs(layered_coupling_map, conf, cxnum):
 
 
 def extract_ind_counts(crs, counts, measure_idle):
-    # it is important to follow bits in int format to match the arrangement 
+    # it is important to follow bits in int format to match the arrangement
     # of classical register in circuit composer in run code
     if not measure_idle:
         bits=flatten_bits(crs); nbits=len(bits)
@@ -308,7 +308,7 @@ def extract_ind_counts(crs, counts, measure_idle):
             idx1 = bit2idx[int(cr[0])]
             idx2 = bit2idx[int(cr[1])]
         ind_counts.update({label:marginal_counts(counts, [idx1, idx2])})
-        
+
         if measure_idle and cr[0] > cr[1]:
             ind_counts[label]['01'], ind_counts[label]['10'] = ind_counts[label].get('10', 0), ind_counts[label].get('01', 0)
 

--- a/qiskit_device_benchmarking/bench_code/mrb/Readme.md
+++ b/qiskit_device_benchmarking/bench_code/mrb/Readme.md
@@ -1,6 +1,6 @@
 # Mirror QV and RB
 
-Code written for https://arxiv.org/abs/2303.02108 and based on the earlier works T. Proctor, S. Seritan, K. Rudinger, E. Nielsen, R. Blume-Kohout, and K. Young, 
+Code written for https://arxiv.org/abs/2303.02108 and based on the earlier works T. Proctor, S. Seritan, K. Rudinger, E. Nielsen, R. Blume-Kohout, and K. Young,
 [Physical Review Letters 129, 150502 (2022)](https://doi.org/10.48550/arXiv.2112.09853) and T. Proctor, K. Rudinger, K. Young, E. Nielsen, and R. Blume-Kohout, [Nature Physics 18, 75 (2022)](https://doi.org/10.48550/arXiv.2008.11294).
 
 Code is based on the qiskit-experiments framework.

--- a/qiskit_device_benchmarking/bench_code/mrb/mirror_qv_analysis.py
+++ b/qiskit_device_benchmarking/bench_code/mrb/mirror_qv_analysis.py
@@ -38,7 +38,7 @@ class MirrorQuantumVolumeAnalysis(BaseAnalysis):
         Calculate the success (fraction of target measured) and polarization
         Optionally calcuate an effective HOP
     """
-    
+
     def _initialize(self, experiment_data: ExperimentData):
         """Initialize curve analysis by setting up the data processor for Mirror
         RB data.
@@ -60,7 +60,7 @@ class MirrorQuantumVolumeAnalysis(BaseAnalysis):
                 raise AnalysisError("QuantumVolume circuits do not all have the same depth.")
 
         num_qubits = self.depth
-        
+
         self.set_options(
             data_processor=DataProcessor(
                 input_key="counts",
@@ -100,14 +100,14 @@ class MirrorQuantumVolumeAnalysis(BaseAnalysis):
                 "Effective Polarization",
             ],
         )
-        
+
         return options
 
-   
+
     def _run_analysis(
             self,
             experiment_data: ExperimentData,
-        ): 
+        ):
 
         results = []
         artifacts = []
@@ -142,7 +142,7 @@ class MirrorQuantumVolumeAnalysis(BaseAnalysis):
             figures = None
         else:
             figures = None
-        
+
         results.append(success_prob_result)
-        
+
         return results+artifacts, figures

--- a/qiskit_device_benchmarking/bench_code/mrb/mirror_rb_analysis.py
+++ b/qiskit_device_benchmarking/bench_code/mrb/mirror_rb_analysis.py
@@ -281,7 +281,7 @@ class _ComputeQuantities(DataAction):
                         success_prob = count / sum(circ_result.values())
                         success_prob_unc = np.sqrt(success_prob * (1 - success_prob))
                         break
-                else:  
+                else:
                     # Compute hamming distance proportions
                     target_bs_to_list = [int(char) for char in target_bs]
                     actual_bs_to_list = [int(char) for char in bitstring]

--- a/qiskit_device_benchmarking/bench_code/prb/Readme.md
+++ b/qiskit_device_benchmarking/bench_code/prb/Readme.md
@@ -1,4 +1,4 @@
 ## Purity RB
 
-Code for running purity RB (notebook [here](https://github.com/qiskit-community/qiskit-device-benchmarking/blob/main/notebooks/device_rb.ipynb)). Purity RB appends post rotations 
-to the RB sequences to calculate Tr(rho^2) as described in the supplement of [arXiv:2302.10881](https://arxiv.org/abs/2302.10881) and previously in the Ignis code base. 
+Code for running purity RB (notebook [here](https://github.com/qiskit-community/qiskit-device-benchmarking/blob/main/notebooks/device_rb.ipynb)). Purity RB appends post rotations
+to the RB sequences to calculate Tr(rho^2) as described in the supplement of [arXiv:2302.10881](https://arxiv.org/abs/2302.10881) and previously in the Ignis code base.

--- a/qiskit_device_benchmarking/bench_code/prb/pur_rb.py
+++ b/qiskit_device_benchmarking/bench_code/prb/pur_rb.py
@@ -115,7 +115,7 @@ class PurityRB(StandardRB):
         circuits = self._sequences_to_circuits(sequences)
         # Add metadata for each circuit
         # trial links all from the same trial
-        # needed for post processing the purity RB 
+        # needed for post processing the purity RB
         for circ_i, circ in enumerate(circuits):
             circ.metadata = {
                 "xval": len(sequences[int(circ_i/3**self.num_qubits)]),
@@ -149,9 +149,9 @@ class PurityRB(StandardRB):
                     qc.sdg(j)
                     qc.sx(j)
                     qc.s(j)
-                    
+
             post_rot.append(self._to_instruction(Clifford(qc), synthesis_opts))
-        
+
         # Circuit generation
         circuits = []
         for i, seq in enumerate(sequences):
@@ -179,5 +179,5 @@ class PurityRB(StandardRB):
                 circ2.append(post_rot[j], circ.qubits)
                 circ2.measure_all()  # includes insertion of the barrier before measurement
                 circuits.append(circ2)
-                
+
         return circuits

--- a/qiskit_device_benchmarking/bench_code/prb/purrb_analysis.py
+++ b/qiskit_device_benchmarking/bench_code/prb/purrb_analysis.py
@@ -21,12 +21,12 @@ from qiskit_experiments.curve_analysis import ScatterTable
 import qiskit_experiments.curve_analysis as curve
 from qiskit_experiments.framework import AnalysisResultData
 from qiskit_experiments.library.randomized_benchmarking import RBAnalysis
-from qiskit_experiments.library.randomized_benchmarking.rb_analysis import (_calculate_epg, 
+from qiskit_experiments.library.randomized_benchmarking.rb_analysis import (_calculate_epg,
                                                                             _exclude_1q_error)
 
 
 class PurityRBAnalysis(RBAnalysis):
-    r"""A class to analyze purity randomized benchmarking experiments. 
+    r"""A class to analyze purity randomized benchmarking experiments.
 
     # section: overview
         This analysis takes only single series.
@@ -74,7 +74,7 @@ class PurityRBAnalysis(RBAnalysis):
     ) -> ScatterTable:
         """Perform data processing from the experiment result payload.
 
-        For purity this converts the counts into Trace(rho^2) and then runs the 
+        For purity this converts the counts into Trace(rho^2) and then runs the
         rest of the standard RB fitters
 
         For now this does it by spoofing a new counts dictionary and then
@@ -119,8 +119,8 @@ class PurityRBAnalysis(RBAnalysis):
                     purity += sampled_expectation_value(trial_raw[ii]['counts'],'IZ')**2/2**nq/3**(nq-1)
                     purity += sampled_expectation_value(trial_raw[ii]['counts'],'ZI')**2/2**nq/3**(nq-1)
 
-            raw_data2[-1]['counts'] = {'0'*nq: int(purity*nshots*10),'1'*nq: int((1-purity)*nshots*10)} 
-                        
+            raw_data2[-1]['counts'] = {'0'*nq: int(purity*nshots*10),'1'*nq: int((1-purity)*nshots*10)}
+
         return super()._run_data_processing(raw_data2,category)
 
 
@@ -143,7 +143,7 @@ class PurityRBAnalysis(RBAnalysis):
         num_qubits = len(self._physical_qubits)
 
         # Calculate EPC
-        # For purity we need to correct by 
+        # For purity we need to correct by
         alpha = fit_data.ufloat_params["alpha"]**0.5
         scale = (2**num_qubits - 1) / (2**num_qubits)
         epc = scale * (1 - alpha)
@@ -197,7 +197,7 @@ class PurityRBAnalysis(RBAnalysis):
                     )
 
         return outcomes
-    
+
     def _generate_fit_guesses(
         self,
         user_opt: curve.FitOptions,
@@ -223,14 +223,14 @@ class PurityRBAnalysis(RBAnalysis):
             alpha_guess = curve.guess.rb_decay(curve_data.x[0:3], curve_data.y[0:3], b=b_guess)
         else:
             alpha_guess = curve.guess.rb_decay(curve_data.x, curve_data.y, b=b_guess)
-            
+
         alpha_guess = alpha_guess**2
-        
+
         if alpha_guess < 0.6:
             a_guess = (curve_data.y[0] - b_guess)
         else:
             a_guess = (curve_data.y[0] - b_guess) / (alpha_guess ** curve_data.x[0])
-            
+
         user_opt.p0.set_if_empty(
             b=b_guess,
             a=a_guess,

--- a/qiskit_device_benchmarking/clops/README.md
+++ b/qiskit_device_benchmarking/clops/README.md
@@ -1,18 +1,18 @@
 # CLOPS Benchmark
 
 This benchmark measures Circuit Layer Operations Per Seconds (CLOPS) of
-parameterized utility scale  hardware efficient circuits. 
- CLOPS measures the steady state throughput of a large quantity of 
- these parameterized circuits that are 
- of width 100 qubits with 100 layers of gates. 
+parameterized utility scale  hardware efficient circuits.
+ CLOPS measures the steady state throughput of a large quantity of
+ these parameterized circuits that are
+ of width 100 qubits with 100 layers of gates.
  Each layer consists of two qubit gates across as many qubits
  as possible that can be done in parallel, followed by a single qubit
- gate(s) on every qubit to allow any arbitrary rotation, with those 
+ gate(s) on every qubit to allow any arbitrary rotation, with those
  rotations being parameterized.
- Parameters are applied to the circuit to generate a large number of 
+ Parameters are applied to the circuit to generate a large number of
  instantiated circuits to be executed on the quantum computer. It is
- up to the vendor on how to optimally execute these circuits for 
- maximal throughput. 
+ up to the vendor on how to optimally execute these circuits for
+ maximal throughput.
 
 CLOPS now supports the new `gen3-turbo` flag for execution path available
 on some of our devices.
@@ -31,7 +31,7 @@ service = QiskitRuntimeService(channel="ibm_quantum",
 # takes about 10 minutes to run
 my_clops_run = clops_benchmark(service, "your-favorite-ibm-quantum-computer")
 
-# To run clops with the new new `gen3-turbo` path, you can specify the 
+# To run clops with the new new `gen3-turbo` path, you can specify the
 # execution path. For the new faster path you should increase the number
 # of circuits to 5,000
 my_clops_run = clops_benchmark(service, "machine supporting gen3-turbo", execution_path='gen3-turbo', num_circuits = 5000)
@@ -55,31 +55,31 @@ Measured clops of ibm_brisbane is 30256
 ## Variations
 
 
-The benchmark code provides several 
- ways to measure CLOPS depending on the capability of the quantum computer. 
+The benchmark code provides several
+ ways to measure CLOPS depending on the capability of the quantum computer.
 
  The "twirling" method uses the native parameterization of the Sampler
- primitive to parameterize the circuit, and optimal batching of the 
+ primitive to parameterize the circuit, and optimal batching of the
  circuits is assumed to be done by the Sampler, freeing the user
  from having to optimize the batch size. The only requirement is
  that the total number of circuits executed needs to be chosen to
  get the system into a steady state to measure CLOPS.
 
  The "parameterized" method is similar, but instead sends an already
- parameterized circuit to the Sampler primitive, along with enough 
- parameters to execute the specified number of circuits. Batching 
+ parameterized circuit to the Sampler primitive, along with enough
+ parameters to execute the specified number of circuits. Batching
  again is handled by the Sampler. This method requires larger bandwidth
  to send in all of the necessary parameters. Currently on IBM systems
- you will need to limit the number of circuits to approximately 160 to 
+ you will need to limit the number of circuits to approximately 160 to
  fit within API job input limits.
 
- The "instantiated" method (not yet implemented) is for systems that cannot natively 
+ The "instantiated" method (not yet implemented) is for systems that cannot natively
  handle parameterized circuits. In this case the circuit parameters
  are bound locally and then sent to the quantum computer for execution.
  This method requires the user to specify the desired size of each
- batch of circuits (so that they can be sent together the quantum computer) 
+ batch of circuits (so that they can be sent together the quantum computer)
  as well as the number of local parallel pipelines to bind parameters and
  create payloads in parallel. The user will need to tune both of these
- parameters to try and optimize performance of the system. This will 
+ parameters to try and optimize performance of the system. This will
  tend to be much slower than on systems that natively support parameterized
  circuits

--- a/qiskit_device_benchmarking/clops/README.md
+++ b/qiskit_device_benchmarking/clops/README.md
@@ -1,18 +1,17 @@
 # CLOPS Benchmark
 
 This benchmark measures Circuit Layer Operations Per Seconds (CLOPS) of
-parameterized utility scale  hardware efficient circuits.
- CLOPS measures the steady state throughput of a large quantity of
- these parameterized circuits that are
- of width 100 qubits with 100 layers of gates.
- Each layer consists of two qubit gates across as many qubits
- as possible that can be done in parallel, followed by a single qubit
- gate(s) on every qubit to allow any arbitrary rotation, with those
- rotations being parameterized.
- Parameters are applied to the circuit to generate a large number of
- instantiated circuits to be executed on the quantum computer. It is
- up to the vendor on how to optimally execute these circuits for
- maximal throughput.
+parameterized utility scale hardware efficient circuits.
+
+CLOPS measures the steady state throughput of a large quantity of these
+parameterized circuits that are of width 100 qubits with 100 layers of
+gates. Each layer consists of two qubit gates across as many qubits as
+possible that can be done in parallel, followed by a single qubit
+gate(s) on every qubit to allow any arbitrary rotation, with those
+rotations being parameterized.  Parameters are applied to the circuit to
+generate a large number of instantiated circuits to be executed on the
+quantum computer. It is up to the vendor on how to optimally execute
+these circuits for maximal throughput.
 
 CLOPS now supports the new `gen3-turbo` flag for execution path available
 on some of our devices.
@@ -55,31 +54,31 @@ Measured clops of ibm_brisbane is 30256
 ## Variations
 
 
-The benchmark code provides several
- ways to measure CLOPS depending on the capability of the quantum computer.
+The benchmark code provides several ways to measure CLOPS depending on
+the capability of the quantum computer.
 
- The "twirling" method uses the native parameterization of the Sampler
- primitive to parameterize the circuit, and optimal batching of the
- circuits is assumed to be done by the Sampler, freeing the user
- from having to optimize the batch size. The only requirement is
- that the total number of circuits executed needs to be chosen to
- get the system into a steady state to measure CLOPS.
+The "twirling" method uses the native parameterization of the Sampler
+primitive to parameterize the circuit, and optimal batching of the
+circuits is assumed to be done by the Sampler, freeing the user
+from having to optimize the batch size. The only requirement is
+that the total number of circuits executed needs to be chosen to
+get the system into a steady state to measure CLOPS.
 
- The "parameterized" method is similar, but instead sends an already
- parameterized circuit to the Sampler primitive, along with enough
- parameters to execute the specified number of circuits. Batching
- again is handled by the Sampler. This method requires larger bandwidth
- to send in all of the necessary parameters. Currently on IBM systems
- you will need to limit the number of circuits to approximately 160 to
- fit within API job input limits.
+The "parameterized" method is similar, but instead sends an already
+parameterized circuit to the Sampler primitive, along with enough
+parameters to execute the specified number of circuits. Batching
+again is handled by the Sampler. This method requires larger bandwidth
+to send in all of the necessary parameters. Currently on IBM systems
+you will need to limit the number of circuits to approximately 160 to
+fit within API job input limits.
 
- The "instantiated" method (not yet implemented) is for systems that cannot natively
- handle parameterized circuits. In this case the circuit parameters
- are bound locally and then sent to the quantum computer for execution.
- This method requires the user to specify the desired size of each
- batch of circuits (so that they can be sent together the quantum computer)
- as well as the number of local parallel pipelines to bind parameters and
- create payloads in parallel. The user will need to tune both of these
- parameters to try and optimize performance of the system. This will
- tend to be much slower than on systems that natively support parameterized
- circuits
+The "instantiated" method (not yet implemented) is for systems that
+cannot natively handle parameterized circuits. In this case the circuit
+parameters are bound locally and then sent to the quantum computer for
+execution.  This method requires the user to specify the desired size of
+each batch of circuits (so that they can be sent together the quantum
+computer) as well as the number of local parallel pipelines to bind
+parameters and create payloads in parallel. The user will need to tune
+both of these parameters to try and optimize performance of the
+system. This will tend to be much slower than on systems that natively
+support parameterized circuits

--- a/qiskit_device_benchmarking/clops/clops_benchmark.py
+++ b/qiskit_device_benchmarking/clops/clops_benchmark.py
@@ -28,39 +28,39 @@ from qiskit_ibm_runtime.execution_span import ExecutionSpan, ExecutionSpans
 CLOPS benchmark
 
 This benchmark measures Circuit Layer Operations Per Seconds (CLOPS) of
-parameterized utility scale  hardware efficient circuits.  CLOPS measures 
-the steady state throughput of a large quantity of  these parameterized 
-circuits that are  of width 100 qubits with 100 layers of gates. 
+parameterized utility scale  hardware efficient circuits.  CLOPS measures
+the steady state throughput of a large quantity of  these parameterized
+circuits that are  of width 100 qubits with 100 layers of gates.
 Each layer consists of two qubit gates across as many qubits
 as possible that can be done in parallel, followed by a single qubit
-gate(s) on every qubit to allow any arbitrary rotation, with those 
-rotations being parameterized.  Parameters are applied to the circuit 
-to generate a large number of  instantiated circuits to be executed on 
-the quantum computer. It is up to the vendor on how to optimally execute 
-these circuits for maximal throughput.  As such, the benchmark code 
-provides several ways to measure CLOPS depending on the capability of 
-the quantum computer. 
+gate(s) on every qubit to allow any arbitrary rotation, with those
+rotations being parameterized.  Parameters are applied to the circuit
+to generate a large number of  instantiated circuits to be executed on
+the quantum computer. It is up to the vendor on how to optimally execute
+these circuits for maximal throughput.  As such, the benchmark code
+provides several ways to measure CLOPS depending on the capability of
+the quantum computer.
 
 The "twirling" method uses the native parameterization of the Sampler
-primitive to parameterize the circuit, and optimal batching of the 
+primitive to parameterize the circuit, and optimal batching of the
 circuits is assumed to be done by the Sampler, freeing the user
 from having to optimize the batch size. The only requirement is
 that the total number of circuits executed needs to be chosen to
 get the system into a steady state to measure CLOPS.
 The "parameterized" method is similar, but instead sends an already
-parameterized circuit to the Sampler primitive, along with enough 
-parameters to execute the specified number of circuits. Batching 
+parameterized circuit to the Sampler primitive, along with enough
+parameters to execute the specified number of circuits. Batching
 again is handled by the Sampler. This method requires larger bandwidth
 to send in all of the necessary parameters.
 
-The "instantiated" method is for systems that cannot natively 
+The "instantiated" method is for systems that cannot natively
 handle parameterized circuits. In this case the circuit parameters
 are bound locally and then sent to the quantum computer for execution.
 This method requires the user to specify the desired size of each
-batch of circuits (so that they can be sent together the quantum computer) 
+batch of circuits (so that they can be sent together the quantum computer)
 as well as the number of local parallel pipelines to bind parameters and
 create payloads in parallel. The user will need to tune both of these
-parameters to try and optimize performance of the system. This will 
+parameters to try and optimize performance of the system. This will
 tend to be much slower than on systems that natively support parameterized
 circuits
 
@@ -110,7 +110,7 @@ def _append_1q_layer_u(
     pars2 = ParameterVector(f"{param_prefix}_2", size)
 
     for i, q in enumerate(qubits):
-        if parameterized: 
+        if parameterized:
             circuit._append(UGate(pars0[i], pars1[i], pars2[i]), [q], [])
         else:
             circuit._append(UGate(1.0, -3.14/2, 3.14/2), [q], [])
@@ -128,7 +128,7 @@ def _append_1q_layer_rzsx(
     pars2 = ParameterVector(f"{param_prefix}_2", size)
 
     for i, q in enumerate(qubits):
-        if parameterized: 
+        if parameterized:
             circuit._append(RZGate(pars0[i]), [q], [])
             circuit._append(SXGate(), [q], [])
             circuit._append(RZGate(pars1[i]), [q], [])
@@ -311,10 +311,10 @@ def create_payload(backend, qc, rng, max_experiments):
 
 
 def run_twirled(
-    backend: Backend, 
+    backend: Backend,
     width: int,
     layers: int,
-    shots: int, 
+    shots: int,
     rep_delay: float,
     num_circuits: int,
     execution_path: str,
@@ -334,10 +334,10 @@ def run_twirled(
 
 
 def run_parameterized(
-    backend: Backend, 
+    backend: Backend,
     width: int,
     layers: int,
-    shots: int, 
+    shots: int,
     rep_delay: float,
     num_circuits: int,
     execution_path: str,
@@ -345,10 +345,10 @@ def run_parameterized(
     (transpiled_circ, parameters) = create_hardware_aware_circuit(width=width, layers=layers, backend=backend, parameterized=True)
     seed = 234987
     rng = np.random.default_rng(seed)
-    
-    param_values = [[rng.uniform(0, np.pi * 2) for idx in range(sum([len(param) for param in parameters]))] 
+
+    param_values = [[rng.uniform(0, np.pi * 2) for idx in range(sum([len(param) for param in parameters]))]
                      for idx in range(num_circuits)]
-    
+
     experimental_opts = {"execution": {"fast_parametric_update": True}}
     options = SamplerOptions(experimental=experimental_opts)
     if execution_path:
@@ -357,7 +357,7 @@ def run_parameterized(
     with Session(backend=backend) as session:
         sampler=Sampler(mode=session, options=options)
         job = sampler.run([(transpiled_circ, param_values , shots)])
-    
+
     return job
 
 class clops_benchmark:
@@ -375,7 +375,7 @@ class clops_benchmark:
         pipelines: int = 1,
         execution_path: Optional[str] = None,
     ):
-        
+
         """Run CLOPS benchmark through Sampler primitive
 
         Args:
@@ -388,14 +388,14 @@ class clops_benchmark:
             rep_delay: Optional, delay between circuits, default is set to system value
             num_circuits: Optional, number of circuits (parameter updates) run for the benchmark
                           default is 1000.  Adjust as necessary to get sufficient iterations.
-                          For non-twirled benchmarking may need to be significantly reduced to 
+                          For non-twirled benchmarking may need to be significantly reduced to
                           meet API input size limits
             circuit_type: Optional, determines how parameters are handled:
-                        "twirled": default value, sends in a single unparameterized circuit and configures 
+                        "twirled": default value, sends in a single unparameterized circuit and configures
                                    Sampler to run `num_circuits` twirls (parameterized) of the circuit
                         "parameterized": sends in a single parameterized circuit with `num_circuits` parameter sets
                         "instantiated": binds parameters locally and sends batches of instantiated circuits to be run
-            batch_size: Optional, indicates how many circuits should be sent in per job to the backend. Only used 
+            batch_size: Optional, indicates how many circuits should be sent in per job to the backend. Only used
                         for `instantiated` circuit_type. Default is None
             pipelines: Optional, number of parallel processes used to instantiate parameters and submit jobs to
                     the backend. Only used for `instantiated` circuit_type.  Default is 1
@@ -411,7 +411,7 @@ class clops_benchmark:
         self.job_attributes = {"backend_name": backend_name, "width": width, "layers": layers, "shots": shots,
                                "rep_delay": rep_delay, "num_circuits": num_circuits, "circuit_type": circuit_type,
                                "batch_size": batch_size, "pipelines": pipelines}
-        
+
         if circuit_type == "twirled":
             self.job = run_twirled(backend, width, layers, shots, rep_delay, num_circuits, execution_path)
             self.clops = self._clops_throughput_sampler
@@ -422,18 +422,18 @@ class clops_benchmark:
             raise ValueError("'circuit_type' instantiated not yet supported")
         else:
             raise ValueError("'circuit_type' " + circuit_type + " invalid")
-        
-        
+
+
     def _clops_throughput_sampler(self):
         """ Measures the overall CLOPS throughput based off of intermediate
-        job metadata returned from the sampler. This metadata indicates the 
+        job metadata returned from the sampler. This metadata indicates the
         start and end time for each sub-job executed on the qpu.  For larger
-        jobs (large number of twirls or large number of circuits/parameters) 
+        jobs (large number of twirls or large number of circuits/parameters)
         jobs are split into chunks that efficiently run on the qpu. To calculate
-        the steady state throughput we use the time from the end of the first 
+        the steady state throughput we use the time from the end of the first
         sub-job to the end of the last sub-job, skipping the startup costs
-        for the first job to get the pipeline full. The goal is to predict 
-        the expected performance for large scale error mitigated workloads 
+        for the first job to get the pipeline full. The goal is to predict
+        the expected performance for large scale error mitigated workloads
         without having to run huge number of circuits"""
 
         result = self.job.result()
@@ -448,7 +448,7 @@ class clops_benchmark:
         end_time_last_sub_job = spans.stop
         end_time_first_sub_job = spans[0].stop
 
-        clops = round(((sum_size - spans[0].size) * self.job_attributes["layers"]) / 
+        clops = round(((sum_size - spans[0].size) * self.job_attributes["layers"]) /
                       (end_time_last_sub_job - end_time_first_sub_job
         ).total_seconds())
 

--- a/qiskit_device_benchmarking/mirror_test/mirror_test.py
+++ b/qiskit_device_benchmarking/mirror_test/mirror_test.py
@@ -12,7 +12,7 @@ from typing import Optional, List
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy import stats
-from qiskit_ibm_runtime import (EstimatorV2 as Estimator, EstimatorOptions, IBMBackend, 
+from qiskit_ibm_runtime import (EstimatorV2 as Estimator, EstimatorOptions, IBMBackend,
                                 RuntimeJobV2 as RuntimeJob)
 from qiskit_ibm_runtime.utils.noise_learner_result import LayerError
 from qiskit.primitives import PrimitiveResult
@@ -147,5 +147,5 @@ def analyze_mirror_result(result: PrimitiveResult,
         plt.xlim((xpts[0],xpts[-1]))
         plt.ylabel("Fraction of observables")
         plt.grid()
-    
+
     return median_error, mean_error, fraction

--- a/qiskit_device_benchmarking/utilities/file_utils.py
+++ b/qiskit_device_benchmarking/utilities/file_utils.py
@@ -18,12 +18,12 @@ import datetime
 def import_yaml(fstr):
     with open(fstr, 'r') as stream:
         data_imp = yaml.safe_load(stream)
-        
+
     return data_imp
 
 def timestamp_name():
     return datetime.datetime.now().strftime('%Y-%m-%d_%H_%M_%S')
-    
+
 def export_yaml(fstr, exp_data):
     with open(fstr, 'w') as fout:
         yaml.dump(exp_data, fout, default_flow_style=None)

--- a/qiskit_device_benchmarking/utilities/gate_map.py
+++ b/qiskit_device_benchmarking/utilities/gate_map.py
@@ -518,7 +518,7 @@ def plot_gate_map(
         [14, 14],
         [14, 15],
     ]
-    
+
     backend_version = _get_backend_interface_version(backend)
     if backend_version <= 1:
         if backend.configuration().simulator:
@@ -543,7 +543,7 @@ def plot_gate_map(
 
     if qubit_coordinates is None:
         raise QiskitError("No matching coordinate found, code has only 127, 133, 156 backends")
-        
+
     return plot_coupling_map(
         num_qubits,
         qubit_coordinates,
@@ -684,7 +684,7 @@ def plot_coupling_map(
     def node_label(node):
         return str(qubit_labels[node])
 
-    
+
     plot = mpl_draw(
         graph,
         pos = qubit_coordinates,

--- a/qiskit_device_benchmarking/utilities/graph_utils.py
+++ b/qiskit_device_benchmarking/utilities/graph_utils.py
@@ -36,30 +36,30 @@ def remove_permutations(paths):
     Returns:
         list of qubit chains without permutations
     """
-    
+
     new_path = []
     for path_i in paths:
-        
+
         #check already in the new_path
         if path_i in new_path:
             continue
-        
+
         #reverse and check
         path_i.reverse()
         if path_i  in new_path:
             continue
         path_i.reverse()
-        
+
         new_path.append(path_i)
-        
-        
+
+
     return new_path
 
 def path_to_edges(paths, coupling_map=None):
-    """Converse a list of paths into a list of edges that are in the 
+    """Converse a list of paths into a list of edges that are in the
     coupling_map if defined
-    
-    If already edges (length 2 path) then convert into the edge that's in the 
+
+    If already edges (length 2 path) then convert into the edge that's in the
     coupling map
 
     Args:
@@ -68,32 +68,32 @@ def path_to_edges(paths, coupling_map=None):
     Returns:
         list of qubit paths in terms of the edges to traverse.
     """
-    
+
     new_path = []
     for path_i in paths:
-        
+
         if len(path_i)>2:
             new_path.append([])
-            
+
         for i in range(len(path_i)-1):
-            
+
             tmp_set = path_i[i:(i+2)]
             if coupling_map is not None:
                 if tuple(tmp_set) not in coupling_map and tmp_set not in coupling_map:
                     tmp_set.reverse()
                     if tuple(tmp_set) not in coupling_map and tmp_set not in coupling_map:
                         raise ValueError('Path not found in coupling map')
-                      
+
             if len(path_i)>2:
                 new_path[-1].append(tmp_set)
             else:
                 new_path.append(tmp_set)
-        
+
     return new_path
 
 
 def build_sys_graph(nq, coupling_map, faulty_qubits=None):
-    
+
     """Build a system graph
 
     Args:
@@ -104,25 +104,25 @@ def build_sys_graph(nq, coupling_map, faulty_qubits=None):
     Returns:
         undirected graph with no duplicate edges
     """
-    
+
     if faulty_qubits is not None:
-        
+
         coupling_map2 = []
-                
+
         for i in coupling_map:
             if (i[0] not in faulty_qubits) and (i[1] not in faulty_qubits):
                 coupling_map2.append(i)
-    
+
         coupling_map = coupling_map2
-    
+
     G = rx.PyDiGraph()
     G.add_nodes_from(range(nq))
     G.add_edges_from_no_data([tuple(x) for x in coupling_map]);
-    
+
     return G.to_undirected(multigraph=False)
 
 def get_iso_qubit_list(G):
-    
+
     """Return a set of lists of isolated (separated by at least one idle qubit)
     qubits using graph coloring
 
@@ -132,7 +132,7 @@ def get_iso_qubit_list(G):
     Returns:
         list of qubit lists
     """
-    
+
     qlists = {}
     node_dict = rx.graph_greedy_color(G)
     for i in node_dict:
@@ -140,15 +140,15 @@ def get_iso_qubit_list(G):
             qlists[node_dict[i]].append(i)
         else:
             qlists[node_dict[i]] = [i]
-    
+
     qlists = list(qlists.values())
     for i in range(len(qlists)):
         qlists[i] = list(np.sort(qlists[i]))
-        
+
     return qlists
 
 def get_disjoint_edge_list(G):
-    
+
     """Return a set of disjoint edges using graph coloring
 
     Args:
@@ -157,7 +157,7 @@ def get_disjoint_edge_list(G):
     Returns:
         list of list of edges
     """
-    
+
     edge_lists = {}
     edge_dict = rx.graph_greedy_edge_color(G)
     for i in edge_dict:
@@ -165,81 +165,81 @@ def get_disjoint_edge_list(G):
             edge_lists[edge_dict[i]].append(G.edge_list()[i])
         else:
             edge_lists[edge_dict[i]] = [G.edge_list()[i]]
-    
+
     return list(edge_lists.values())
 
 def get_separated_sets(G, node_sets, min_sep=1, nsets=-1):
-    
+
     """Given a list node sets separate out into lists where
     the sets in each list are separated by min_sep
-    
+
     This could be quite slow!
 
     Args:
         G: system graph
-        node_sets: list of list of nodes 
+        node_sets: list of list of nodes
         min_sep: minimum separation between node sets
         nsets: number of sets to truncate at, if -1 then make all sets
 
     Returns:
         list of list of list of nodes each separated by min_sep
     """
-    
+
     node_sets_sep = [[]]
     cur_ind1 = 0
     cur_ind2 = 0
-    
+
     node_sets_tmp = copy.deepcopy(node_sets)
 
     #get all node to node distances in a dictionary
     all_dists = rx.all_pairs_dijkstra_path_lengths(G, lambda a: 1)
-    
+
     while (len(node_sets_tmp)>0):
         if cur_ind2>=len(node_sets_tmp):
 
             if nsets>0 and (cur_ind1+2)>nsets:
                 break
-            
+
             node_sets_sep.append([])
             cur_ind1 += 1
             cur_ind2 = 0
-                            
+
         add_set = True
         for node_set in node_sets_sep[cur_ind1]:
-            
+
             if not sets_min_dist(all_dists, node_set, node_sets_tmp[cur_ind2], min_sep):
                 add_set = False
                 cur_ind2 += 1
                 break
-            
+
         if add_set:
             node_sets_sep[cur_ind1].append(node_sets_tmp[cur_ind2])
             node_sets_tmp.pop(cur_ind2)
 
 
-    return node_sets_sep            
-        
+    return node_sets_sep
+
 def sets_min_dist(dist_dict, set1, set2, min_sep):
     """Calculate if two sets are min_sep apart
 
     Args:
         dist_dict: dictionary of distances between nodes
         set1,2: the two sets
-        min_sep: minimum separation 
+        min_sep: minimum separation
 
     Returns:
         True/False
     """
-    
+
     #dummy check
     if set(set1) & set(set2):
         return False
-    
+
     for i in set1:
         for j in set2:
             if dist_dict[i][j] < min_sep:
                 return False
-            
+
     return True
 
 def create_graph_dict(

--- a/qiskit_device_benchmarking/utilities/layer_fidelity_utils.py
+++ b/qiskit_device_benchmarking/utilities/layer_fidelity_utils.py
@@ -13,7 +13,7 @@
 Utilities for layer fidelity
 """
 
-import numpy as np 
+import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
 from pandas import DataFrame
@@ -43,7 +43,7 @@ def run_lf_chain(
     - nseeds
     - cliff_lengths
     - nshots
-    
+
     Returns:
     - List of ExperimentData objects
     """
@@ -120,7 +120,7 @@ def run_lf_chain(
 def get_rb_data(exp_data: ExperimentData)-> pd.DataFrame:
     """ Extract raw and fitted RB data from a layer fidelity experiment.
     Data is exracted for all pairs of qubits in the chain.
-    
+
     Args:
         exp_data: ExperimentData object
 
@@ -146,18 +146,18 @@ def get_rb_data(exp_data: ExperimentData)-> pd.DataFrame:
     return rb_data_df
 
 def reconstruct_lf_per_length(exp_data: ExperimentData, qchain: list[int], backend: IBMBackend) -> pd.DataFrame:
-    """ Extracts the lf and eplg values from a layer fidelity experiment for all 
+    """ Extracts the lf and eplg values from a layer fidelity experiment for all
     subchain lengths ranging from l=4 to l= length of qchain. Saves the data in a
     DataFrame that contains the current legnth, the subchain with the highest lf value,
     and lf and eplg arrays for that given length.
-    
+
     Args:
     - best_qubit_chains: List of chains to run
     - backend
     - nseeds
     - cliff_lengths
     - nshots
-    
+
     Returns:
     - results_per_chain: pd.DataFrame
     """
@@ -185,7 +185,7 @@ def reconstruct_lf_per_length(exp_data: ExperimentData, qchain: list[int], backe
         pfs = [pfdf.loc[pfdf[pfdf.qubits == qubits].index[0], 'value'] for qubits in full_layer]
         pfs = list(map(lambda x: x.n if x != 0 else 0, pfs))
         pfs[0] = pfs[0] ** 2
-        pfs[-1] = pfs[-1] ** 2        
+        pfs[-1] = pfs[-1] ** 2
         pfs[0] = pfs[0] ** 2
         pfs[-1] = pfs[-1] ** 2
 
@@ -229,7 +229,7 @@ def reconstruct_lf_per_length(exp_data: ExperimentData, qchain: list[int], backe
     # Save data
     results_per_chain = pd.DataFrame.from_dict(results_per_chain)
     return results_per_chain
-    
+
 
 def make_lf_eplg_plots(
     backend: IBMBackend,
@@ -239,7 +239,7 @@ def make_lf_eplg_plots(
 ):
     """ Make layer fidelity and eplg plots for a given chain. Values
     are extracted from the provided experiment object.
-    
+
     Args:
     - exp_data: ExperimentData object
     - chain: list of qubits in chain
@@ -274,7 +274,7 @@ def make_lf_eplg_plots(
         pfs = [pfdf.loc[pfdf[pfdf.qubits == qubits].index[0], 'value'] for qubits in full_layer]
         pfs = list(map(lambda x: x.n if x != 0 else 0, pfs))
         pfs[0] = pfs[0] ** 2
-        pfs[-1] = pfs[-1] ** 2        
+        pfs[-1] = pfs[-1] ** 2
         pfs[0] = pfs[0] ** 2
         pfs[-1] = pfs[-1] ** 2
 
@@ -336,7 +336,7 @@ def get_lf_chain(
     chain_length: int=100
 ):
     """ Get the chain reported from the backend for length chain_length
-    
+
     Args:
     - backend: ibm backend
     - chain_length: the chain length to return
@@ -348,19 +348,19 @@ def get_lf_chain(
     for i in backend.properties().general_qlists:
         if i['name']=='lf_%d'%chain_length:
             return i['qubits']
-        
+
     return None
 
 def get_grids(
         backend: IBMBackend,
 ):
     """ Return the grid chains for the different backends
-    
+
     Args:
     - backend: ibm backend
 
     Return:
-    - list of list of chains: list of list of chains for the grids to run. Each 
+    - list of list of chains: list of list of chains for the grids to run. Each
     sub list is a list of chains that can be run in one experiment, each list in that sublist
     is a continuous path
     """
@@ -409,7 +409,7 @@ def get_grids(
         raise ValueError('No grids defined for qubit number %d'%backend.nqubits)
 
     grid_chains = [horz_chain, vert_chain]
-    
+
     return grid_chains
 
 def df_to_error_dict(
@@ -418,7 +418,7 @@ def df_to_error_dict(
 ):
     """ Take in the dataframe from the layer fidelity experiment
     and convert it to a dictionary of gate errors
-    
+
     Args:
     - lf_df: Dataframe from layer fidelity experiment
     - gate_list: List of gates in the layer fidelity experiment
@@ -435,9 +435,9 @@ def df_to_error_dict(
         gate_pf = pfdf[pfdf.qubits == tuple(gate)].iloc[0].value.nominal_value
 
         err_rb_dict['%d_%d'%(gate[0],gate[1])] = 4/5*(1-gate_pf)
-    
+
     return err_rb_dict
-    
+
 
 def make_error_dict(
         backend: IBMBackend,
@@ -445,7 +445,7 @@ def make_error_dict(
         keep_perm: bool=False
 ):
     """ Convert a backend into a dictionary of errors for each edge
-    
+
     Args:
     - backend: ibm backend
     - two_q_gate: the two qubit gate type
@@ -465,9 +465,9 @@ def make_error_dict(
         if not keep_perm:
             if '%d_%d'%(i[1],i[0]) in err_dict:
                 continue
-        
+
         err_dict['%d_%d'%(i[0],i[1])] = props.gate_error(two_q_gate, i)
-    
+
 
     return err_dict
 
@@ -476,18 +476,18 @@ def update_error_dict(
         new_error_dicts: dict,
         update_perm: bool=True,
 ):
-    """ Update errors in error_dict with the errors from the 
+    """ Update errors in error_dict with the errors from the
     new_error_dict
-    
+
     Args:
     - error_dict: original error dictionary (assume complete)
-    - new_error_dicts: list of new error dictionaries 
+    - new_error_dicts: list of new error dictionaries
     - update_perm: treat Q0_Q1 the same as Q1_Q0
-    
+
     Return:
     - updated error dictionary
     """
-    
+
     for gate in error_dict:
         updated_errs = []
         for i in new_error_dicts:
@@ -498,9 +498,9 @@ def update_error_dict(
                 rgate = '%s_%s'%(gate.split('_')[1],gate.split('_')[0])
                 if rgate in i:
                     updated_errs.append(i[rgate])
-    
-    
+
+
         if len(updated_errs)>0:
             error_dict[gate] = float(np.mean(updated_errs))
-    
+
     return error_dict

--- a/qiskit_device_benchmarking/verification/Readme.md
+++ b/qiskit_device_benchmarking/verification/Readme.md
@@ -12,7 +12,7 @@ opt_level: 1
 trials: 10
 shots: 200
 ```
-Generates an output yaml (timestamped) with the results. There are two types of circuits for the benchmarking. 
+Generates an output yaml (timestamped) with the results. There are two types of circuits for the benchmarking.
 Mirror QV circuits which are all-to-all and HE (hardware-efficient) Mirror QV circuits which are layers of random SU(4) assuming nearest neighbor on a chain.
 
 The output can be turned into plots with `bench_analyze.py`, e.g. `python bench_analyze.py -f MQV_2024-04-27_06_19_32.yaml -v max --plot` will product a plot of all the maximum results over the sets from the listed file. Plots are generated as pdf.
@@ -24,4 +24,4 @@ backends: [ibm_fez]
 channel: 'ibm_quantum' or 'imb_cloud'
 ```
 
-Circuits are based on the code written for https://arxiv.org/abs/2303.02108 which was based on the earlier work by Proctor et al [Phys. Rev. Lett. 129, 150502 (2022)](https://doi.org/10.48550/arXiv.2112.09853). 
+Circuits are based on the code written for https://arxiv.org/abs/2303.02108 which was based on the earlier work by Proctor et al [Phys. Rev. Lett. 129, 150502 (2022)](https://doi.org/10.48550/arXiv.2112.09853).

--- a/qiskit_device_benchmarking/verification/bench_analyze.py
+++ b/qiskit_device_benchmarking/verification/bench_analyze.py
@@ -20,10 +20,10 @@ import matplotlib.pyplot as plt
 
 
 def generate_plot(out_data, config_data, args):
-    
+
     """Generate a plot from the fast_bench data
-    
-    Generates a plot of the name result_plot_<XXX>.pdf where XXX is the 
+
+    Generates a plot of the name result_plot_<XXX>.pdf where XXX is the
     current date and time
 
     Args:
@@ -34,12 +34,12 @@ def generate_plot(out_data, config_data, args):
     Returns:
         None
     """
-    
+
     markers = ['o','x','.','s','^','v','*']
-    
+
     for i, backend in enumerate(out_data):
         plt.semilogy(out_data[backend][0],out_data[backend][1], label=backend, marker=markers[np.mod(i,len(markers))])
-        
+
     plt.legend()
     plt.xlabel('Depth')
     plt.ylabel('Success Probability (%s over sets)'%args.value)
@@ -50,36 +50,36 @@ def generate_plot(out_data, config_data, args):
     plt.grid(True)
     plt.savefig('result_plot_%s.pdf'%fu.timestamp_name())
     plt.close()
-    
+
     return
 
 
 if __name__ == '__main__':
-    
+
     """Analyze a benchmarking run from `fast_bench.py`
 
     Args:
         Call -h for arguments
 
     """
-    
+
     parser = argparse.ArgumentParser(description = 'Analyze the results of a '
                                      + 'benchmarking run.')
     parser.add_argument('-f', '--files', help='Comma separated list of files')
     parser.add_argument('-b', '--backends', help='Comma separated list of '
                         + 'backends to plot. If empty plot all.')
-    parser.add_argument('-v', '--value', help='Statistical value to compute', 
+    parser.add_argument('-v', '--value', help='Statistical value to compute',
                         choices=['mean','median', 'max', 'min'], default='mean')
     parser.add_argument('--plot', help='Generate a plot', action='store_true')
     args = parser.parse_args()
-    
+
     #import from results files and concatenate into a larger results
     results_dict = {}
     for file in args.files.split(','):
         results_dict_new = fu.import_yaml(file)
-        
+
         for backend in results_dict_new:
-            
+
             if backend not in results_dict:
                 results_dict[backend] = results_dict_new[backend]
             elif backend!='config':
@@ -89,35 +89,35 @@ if __name__ == '__main__':
                         err_str = 'Depth %s already exists for backend %s, duplicate results'%(depth,backend)
                         raise ValueError(err_str)
                     else:
-                        
+
                         #check the metadata is the same
                         #TO DO
-                        
+
                         results_dict[backend][depth] = results_dict_new[backend][depth]
-                        
-                        
-    if args.backends is not None:                    
+
+
+    if args.backends is not None:
         backends_filt = args.backends.split(',')
     else:
         backends_filt = []
-    
+
     out_data = {}
-    
-    
+
+
     for backend in results_dict:
-            
+
         if len(backends_filt)>0:
             if backend not in backends_filt:
                 continue
-        
+
         if backend=='config':
             continue
         print(backend)
         depth_list = []
         depth_list_i = []
-        
+
         out_data[backend] = []
-        
+
         for depth in results_dict[backend]:
             if depth=='job_ids':
                 continue
@@ -130,10 +130,10 @@ if __name__ == '__main__':
                 depth_list.append(np.min(results_dict[backend][depth]['mean']))
             else:
                 depth_list.append(np.median(results_dict[backend][depth]['mean']))
-            
+
         print('Backend %s'%backend)
         print('Depths: %s'%depth_list_i)
-        
+
         if args.value=='mean':
             print('Means: %s'%depth_list)
         elif args.value=='max':
@@ -142,19 +142,19 @@ if __name__ == '__main__':
             print('Min: %s'%depth_list)
         else:
             print('Median: %s'%depth_list)
-        
+
         out_data[backend].append(depth_list_i)
         out_data[backend].append(depth_list)
-            
-            
+
+
     if args.plot:
-        
+
         generate_plot(out_data, results_dict['config'], args)
-        
+
     elif args.plot:
         print('Need to run mean/max also')
-            
-            
-            
-    
-    
+
+
+
+
+

--- a/qiskit_device_benchmarking/verification/count_analyze.py
+++ b/qiskit_device_benchmarking/verification/count_analyze.py
@@ -20,10 +20,10 @@ import matplotlib.pyplot as plt
 
 
 def generate_plot(out_data, degree_data, args):
-    
+
     """Generate a bar plot of the qubit numbers of each backend
-    
-    Generates a plot of the name count_plot_<XXX>.pdf where XXX is the 
+
+    Generates a plot of the name count_plot_<XXX>.pdf where XXX is the
     current date and time
 
     Args:
@@ -34,43 +34,43 @@ def generate_plot(out_data, degree_data, args):
     Returns:
         None
     """
-    
+
     count_data = np.array([out_data[i] for i in out_data])
     degree_data = np.array([degree_data[i] for i in out_data])
     backend_lbls = np.array([i for i in out_data])
     sortinds = np.argsort(count_data)
-    
+
     plt.bar(backend_lbls[sortinds], count_data[sortinds])
     plt.xticks(rotation=45, ha='right')
-    
+
     ax1 = plt.gca()
 
     if args.degree:
         ax2 = ax1.twinx()
         ax2.plot(range(len(sortinds)),degree_data[sortinds],marker='x', color='black')
         ax2.set_ylabel('Average Degree')
-    
-    
-        
+
+
+
     plt.xlabel('Backend')
     plt.grid(axis='y')
     ax1.set_ylabel('Largest Connected Region')
     plt.title('CHSH Test on Each Edge to Determine Qubit Count')
     plt.savefig('count_plot_%s.pdf'%fu.timestamp_name(),bbox_inches='tight')
     plt.close()
-    
+
     return
 
 
 if __name__ == '__main__':
-    
+
     """Analyze a benchmarking run from `fast_bench.py`
 
     Args:
         Call -h for arguments
 
     """
-    
+
     parser = argparse.ArgumentParser(description = 'Analyze the results of a '
                                      + 'benchmarking run.')
     parser.add_argument('-f', '--files', help='Comma separated list of files')
@@ -79,59 +79,59 @@ if __name__ == '__main__':
     parser.add_argument('--plot', help='Generate a plot', action='store_true')
     parser.add_argument('--degree', help='Add degree to the plot', action='store_true')
     args = parser.parse_args()
-    
+
     #import from results files and concatenate into a larger results
     results_dict = {}
     for file in args.files.split(','):
         results_dict_new = fu.import_yaml(file)
-        
+
         for backend in results_dict_new:
-            
+
             if backend not in results_dict:
                 results_dict[backend] = results_dict_new[backend]
             elif backend!='config':
                 #backend in the results dict but maybe not that depth
-                
+
                 err_str = 'Backend %s already exists, duplicate results'%(backend)
                 raise ValueError(err_str)
-                    
-                        
-                        
-    if args.backends is not None:                    
+
+
+
+    if args.backends is not None:
         backends_filt = args.backends.split(',')
     else:
         backends_filt = []
-    
+
     count_data = {}
     degree_data = {}
-    
-    
+
+
     for backend in results_dict:
-            
+
         if len(backends_filt)>0:
             if backend not in backends_filt:
                 continue
-        
+
         if backend=='config':
             continue
-        
-        
-       
+
+
+
         count_data[backend] = results_dict[backend]['largest_region']
         degree_data[backend] = results_dict[backend]['average_degree']
         print('Backend %s, Largest Connected Region: %d'%(backend,count_data[backend]))
         print('Backend %s, Average Degree: %f'%(backend,degree_data[backend]))
-    
-    
-    
+
+
+
     if args.plot:
-        
+
         generate_plot(count_data, degree_data, args)
-        
+
     elif args.plot:
         print('Need to run mean/max also')
-            
-            
-            
-    
-    
+
+
+
+
+

--- a/qiskit_device_benchmarking/verification/fast_bench.py
+++ b/qiskit_device_benchmarking/verification/fast_bench.py
@@ -30,9 +30,9 @@ import warnings
 from qiskit.circuit import Gate
 xslow = Gate(name='xslow', num_qubits=1, params=[])
 
-def run_bench(hgp, backends, depths=[8], trials=10, 
+def run_bench(hgp, backends, depths=[8], trials=10,
               nshots=100, he=True, dd=True, opt_level=3, act_name=''):
-    
+
     """Run a benchmarking test (mirror QV) on a set of devices
 
     Args:
@@ -52,23 +52,23 @@ def run_bench(hgp, backends, depths=[8], trials=10,
     """
 
     warnings.filterwarnings("error", message=".*run.*", category=DeprecationWarning, append=False)
-    
+
     #load the service
     service = QiskitRuntimeService(name=act_name)
     job_list = []
     result_dict = {}
-    result_dict['config'] = {'hgp': hgp, 'depths': depths, 
-                             'trials': trials, 
-                             'nshots': nshots, 
+    result_dict['config'] = {'hgp': hgp, 'depths': depths,
+                             'trials': trials,
+                             'nshots': nshots,
                              'dd': dd,
                              'he': he,
                               'pregenerated': False,
                               'opt_level': opt_level,
                               'act_name': act_name}
-    
-    
+
+
     print('Running Fast Bench with options %s'%result_dict['config'])
-    
+
     #run all the circuits
     for backend in backends:
         print('Loading backend %s'%backend)
@@ -76,14 +76,14 @@ def run_bench(hgp, backends, depths=[8], trials=10,
         backend_real=service.backend(backend,instance=hgp)
         mqv_exp_list_d = []
         for depth in depths:
-    
+
             print('Generating Depth %d Circuits for Backend %s'%(depth, backend))
-            
+
             result_dict[backend][depth] = {}
-            
-    
-            #compute the sets for this 
-            #NOTE: I want to replace this with fixed sets from 
+
+
+            #compute the sets for this
+            #NOTE: I want to replace this with fixed sets from
             #a config file!!!
             nq = backend_real.configuration().n_qubits
             coupling_map = backend_real.configuration().coupling_map
@@ -91,30 +91,30 @@ def run_bench(hgp, backends, depths=[8], trials=10,
             paths = rx.all_pairs_all_simple_paths(G,depth,depth)
             paths = gu.paths_flatten(paths)
             new_sets = gu.get_separated_sets(G,paths,min_sep=2,nsets=1)
-    
+
             mqv_exp_list = []
-            
+
             result_dict[backend][depth]['sets'] = new_sets[0]
-            
-            
+
+
             #Construct mirror QV circuits on each parallel set
             for qset in new_sets[0]:
-                
+
                 #generate the circuits
                 mqv_exp = MirrorQuantumVolume(qubits=qset,backend=backend_real,trials=trials,
                                       pauli_randomize=True, he = he)
-        
-    
-                mqv_exp.analysis.set_options(plot=False, 
+
+
+                mqv_exp.analysis.set_options(plot=False,
                                              calc_hop=False,
                                              analyzed_quantity='Success Probability')
-                
+
                 #Do this so it won't compile outside the qubit sets
                 cust_map = []
                 for i in coupling_map:
                     if i[0] in qset and i[1] in qset:
                         cust_map.append(i)
-                
+
                 basis_gates = backend_real.configuration().basis_gates
                 if 'xslow' in basis_gates:
                     basis_gates.remove('xslow')
@@ -125,32 +125,32 @@ def run_bench(hgp, backends, depths=[8], trials=10,
                 cust_target = Target.from_configuration(basis_gates = basis_gates,
                                                        num_qubits=nq,
                                                        coupling_map=CouplingMap(cust_map))
-                
+
                 mqv_exp.set_transpile_options(target=cust_target, optimization_level=opt_level)
                 mqv_exp_list.append(mqv_exp)
-            
-                
+
+
             new_exp_mqv = ParallelExperiment(mqv_exp_list, backend=backend_real, flatten_results=False)
             if dd:
                 #this forces the circuits to have DD on them
                 print('Transpiling and DD')
                 for i in mqv_exp_list:
                     i.dd_circuits()
-                
-            
+
+
             mqv_exp_list_d.append(new_exp_mqv)
-            
+
         new_exp_mqv = BatchExperiment(mqv_exp_list_d, backend=backend_real, flatten_results=False)
         new_exp_mqv.set_run_options(shots=nshots)
         job_list.append(new_exp_mqv.run())
         result_dict[backend]['job_ids'] = job_list[-1].job_ids
-        
-        
+
+
     #get the jobs back
     for i, backend in enumerate(backends):
-        
+
         print('Loading results for backend: %s'%backend)
-        
+
         expdata = job_list[i]
         try:
             expdata.block_for_results()
@@ -159,15 +159,15 @@ def run_bench(hgp, backends, depths=[8], trials=10,
             print('Error loading backend %s results'%backend)
             result_dict.pop(backend)
             continue
-        
+
         for j, depth in enumerate(depths):
-    
+
             result_dict[backend][depth]['data'] = []
             result_dict[backend][depth]['mean'] = []
             result_dict[backend][depth]['std'] = []
-    
+
             for k in range(len(result_dict[backend][depth]['sets'])):
-    
+
                 result_dict[backend][depth]['data'].append([float(probi) for probi in list(expdata.child_data()[j].child_data()[k].artifacts()[0].data)])
                 result_dict[backend][depth]['mean'].append(float(np.mean(result_dict[backend][depth]['data'][-1])))
                 result_dict[backend][depth]['std'].append(float(np.std(result_dict[backend][depth]['data'][-1])))
@@ -179,46 +179,46 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description = 'Run fast benchmark of '
                                      + 'devices using mirror. Specify a config '
                                      +' yaml and override settings on the command line')
-    parser.add_argument('-c', '--config', help='config file name', 
+    parser.add_argument('-c', '--config', help='config file name',
                         default='config.yaml')
     parser.add_argument('-b', '--backend', help='Specify backend and override '
                         + 'backend_group')
-    parser.add_argument('-bg', '--backend_group', 
-                        help='specify backend group in config file', 
+    parser.add_argument('-bg', '--backend_group',
+                        help='specify backend group in config file',
                         default='backends')
     parser.add_argument('--hgp', help='specify hgp')
     parser.add_argument('--he', help='Hardware efficient', action='store_true')
     parser.add_argument('--name', help='Account name', default='')
     args = parser.parse_args()
-    
+
     #import from config
     config_dict = fu.import_yaml(args.config)
     print('Config File Found')
     print(config_dict)
-    
+
     #override from the command line
     if args.backend is not None:
         backends = [args.backend]
     else:
         backends = config_dict[args.backend_group]
-        
+
     if args.hgp is not None:
         hgp = args.hgp
     else:
         hgp = config_dict['hgp']
-        
+
     if args.he is True:
         he = True
     else:
         he = config_dict['he']
-        
+
     opt_level = config_dict['opt_level']
     dd = config_dict['dd']
     depths = config_dict['depths']
     trials = config_dict['trials']
     nshots = config_dict['shots']
-        
+
     #print(hgp, backends, he, opt_level, dd, depths, trials, nshots)
-    
-    run_bench(hgp, backends, depths=depths, trials=trials, 
+
+    run_bench(hgp, backends, depths=depths, trials=trials,
               nshots=nshots, he=he, dd=dd, opt_level=opt_level, act_name=args.name)

--- a/qiskit_device_benchmarking/verification/fast_count.py
+++ b/qiskit_device_benchmarking/verification/fast_count.py
@@ -24,7 +24,7 @@ import qiskit_device_benchmarking.utilities.graph_utils as gu
 from  qiskit_device_benchmarking.bench_code.bell import CHSHExperiment
 
 def run_count(hgp, backends, nshots=100, act_name=''):
-    
+
     """Run a chsh inequality on a number of devices
 
     Args:
@@ -36,28 +36,28 @@ def run_count(hgp, backends, nshots=100, act_name=''):
     Returns:
         flat list of all the edges
     """
-    
+
     #load the service
     service = QiskitRuntimeService(name=act_name)
     job_list = []
     result_dict = {}
-    result_dict['config'] = {'hgp': hgp,  
-                             'nshots': nshots, 
+    result_dict['config'] = {'hgp': hgp,
+                             'nshots': nshots,
                               'act_name': act_name}
-    
-    
+
+
     print('Running Fast Count with options %s'%result_dict['config'])
-    
+
     #run all the circuits
     for backend in backends:
         print('Loading backend %s'%backend)
         result_dict[backend] = {}
         backend_real=service.backend(backend,instance=hgp)
         chsh_exp_list_b = []
-        
 
-        #compute the sets for this 
-        #NOTE: I want to replace this with fixed sets from 
+
+        #compute the sets for this
+        #NOTE: I want to replace this with fixed sets from
         #a config file!!!
         nq = backend_real.configuration().n_qubits
         coupling_map = backend_real.configuration().coupling_map
@@ -74,45 +74,45 @@ def run_count(hgp, backends, nshots=100, act_name=''):
         #make into separate sets
         sep_sets = gu.get_separated_sets(G, paths, min_sep=2)
 
-        
-        
+
+
         result_dict[backend]['sets'] = sep_sets
-        
-        
+
+
         #Construct mirror QV circuits on each parallel set
         for qsets in sep_sets:
-            
+
             chsh_exp_list = []
-            
-            for qset in qsets:    
-                
+
+            for qset in qsets:
+
                 #generate the circuits
                 chsh_exp = CHSHExperiment(physical_qubits=qset,backend=backend_real)
-        
-    
+
+
                 chsh_exp.set_transpile_options(optimization_level=1)
                 chsh_exp_list.append(chsh_exp)
-        
-            
-            new_exp_chsh = ParallelExperiment(chsh_exp_list, 
-                                             backend=backend_real, 
+
+
+            new_exp_chsh = ParallelExperiment(chsh_exp_list,
+                                             backend=backend_real,
                                              flatten_results=False)
-            
+
             chsh_exp_list_b.append(new_exp_chsh)
-        
-        new_exp_chsh = BatchExperiment(chsh_exp_list_b, backend=backend_real, 
+
+        new_exp_chsh = BatchExperiment(chsh_exp_list_b, backend=backend_real,
                                       flatten_results=False)
-        
+
         new_exp_chsh.set_run_options(shots=nshots)
         job_list.append(new_exp_chsh.run())
         result_dict[backend]['job_ids'] = job_list[-1].job_ids
-        
-        
+
+
     #get the jobs back
     for i, backend in enumerate(backends):
-        
+
         print('Loading results for backend: %s'%backend)
-        
+
         expdata = job_list[i]
         try:
             expdata.block_for_results()
@@ -121,19 +121,19 @@ def run_count(hgp, backends, nshots=100, act_name=''):
             print('Error loading backend %s results'%backend)
             result_dict.pop(backend)
             continue
-        
+
         result_dict[backend]['chsh_values'] = {}
-        
+
         for qsets_i, qsets in enumerate(result_dict[backend]['sets']):
-                        
-            for qset_i, qset in enumerate(qsets): 
-                
-                
+
+            for qset_i, qset in enumerate(qsets):
+
+
                 anal_res = expdata.child_data()[qsets_i].child_data()[qset_i].analysis_results()[0]
                 qedge = '%d_%d'%(anal_res.device_components[0].index,anal_res.device_components[1].index)
                 result_dict[backend]['chsh_values'][qedge] = anal_res.value
-            
-    
+
+
         #calculate number of connected qubits
         G = nx.Graph()
 
@@ -141,33 +141,33 @@ def run_count(hgp, backends, nshots=100, act_name=''):
         for i in result_dict[backend]['chsh_values']:
             if result_dict[backend]['chsh_values'][i]>=2:
                 G.add_edge(int(i.split('_')[0]),int(i.split('_')[1]))
-                
-                
+
+
         #catch error if the graph is empty
         try:
             largest_cc = max(nx.connected_components(G), key=len)
-            
+
             #look at the average degree of the largest region
             avg_degree = 0
             for i in largest_cc:
                 avg_degree += nx.degree(G,i)
-            
+
             avg_degree = avg_degree/len(largest_cc)
-            
+
         except:
-            
+
             largest_cc = {}
             avg_degree = 1
-            
-        
+
+
 
         result_dict[backend]['largest_region'] = len(largest_cc)
         result_dict[backend]['average_degree'] = avg_degree
 
 
-        
 
-      
+
+
     fu.export_yaml('CHSH_' + fu.timestamp_name() + '.yaml', result_dict)
 
 
@@ -175,41 +175,41 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description = 'Run fast benchmark of '
                                      + 'qubit count using chsh. Specify a config '
                                      +' yaml and override settings on the command line')
-    parser.add_argument('-c', '--config', help='config file name', 
+    parser.add_argument('-c', '--config', help='config file name',
                         default='config.yaml')
     parser.add_argument('-b', '--backend', help='Specify backend and override '
                         + 'backend_group')
-    parser.add_argument('-bg', '--backend_group', 
-                        help='specify backend group in config file', 
+    parser.add_argument('-bg', '--backend_group',
+                        help='specify backend group in config file',
                         default='backends')
     parser.add_argument('--hgp', help='specify hgp')
     parser.add_argument('--shots', help='specify number of shots')
     parser.add_argument('--name', help='Account name', default='')
     args = parser.parse_args()
-    
+
     #import from config
     config_dict = fu.import_yaml(args.config)
     print('Config File Found')
     print(config_dict)
-    
+
     #override from the command line
     if args.backend is not None:
         backends = [args.backend]
     else:
         backends = config_dict[args.backend_group]
-        
+
     if args.hgp is not None:
         hgp = args.hgp
     else:
         hgp = config_dict['hgp']
-        
+
     if args.shots is not None:
         nshots = int(args.shots)
     else:
         nshots = config_dict['shots']
-        
-    
-        
+
+
+
     #print(hgp, backends, he, opt_level, dd, depths, trials, nshots)
-    
+
     run_count(hgp, backends, nshots=nshots, act_name=args.name)

--- a/qiskit_device_benchmarking/verification/fast_layer_fidelity.py
+++ b/qiskit_device_benchmarking/verification/fast_layer_fidelity.py
@@ -21,7 +21,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 from typing import Dict, List, Tuple
 import datetime
-import os 
+import os
 
 from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_ibm_runtime.ibm_backend import IBMBackend
@@ -42,8 +42,8 @@ def run_fast_lf(backends: List[str],
     nshots: int,
     act_name: str,
     hgp: str):
-    
-    # Make a general experiment folder 
+
+    # Make a general experiment folder
     parent_path = os.path.join(os.getcwd(), 'layer_fidelity')
     try:
         print(f'Creating folder {parent_path}')
@@ -52,12 +52,12 @@ def run_fast_lf(backends: List[str],
         pass
     print(f'Changing directory to {parent_path}')
     os.chdir(parent_path)
-    
+
     # Load the service
     print('Loading service')
     service = QiskitRuntimeService(name=act_name)
-    
-    for backend_name in backends:    
+
+    for backend_name in backends:
         # Make an experiment folder each backend
         time = datetime.datetime.now().strftime('%Y-%m-%d-%H.%M.%S')
         directory = f"{time}_{backend_name}_layer_fidelity"
@@ -66,7 +66,7 @@ def run_fast_lf(backends: List[str],
         os.mkdir(path)
         print(f'Changing directory to {path}')
         os.chdir(path)
-        
+
         # Get the real backend
         print(f'Getting backend {backend_name}')
         backend = service.backend(backend_name, instance=hgp)
@@ -112,12 +112,12 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description = 'Run fast layer fidelity '
                                      + 'on reported qikist chain. Specify a config '
                                      +' yaml and override settings on the command line')
-    parser.add_argument('-c', '--config', help='config file name', 
+    parser.add_argument('-c', '--config', help='config file name',
                         default='config.yaml')
     parser.add_argument('-b', '--backend', help='Specify backend and override '
                         + 'backend_group')
-    parser.add_argument('-bg', '--backend_group', 
-                        help='specify backend group in config file', 
+    parser.add_argument('-bg', '--backend_group',
+                        help='specify backend group in config file',
                         default='backends')
     parser.add_argument('--hgp', help='specify hgp / qiskit instance')
     parser.add_argument('--name', help='Account name', default='')
@@ -130,34 +130,34 @@ if __name__ == '__main__':
         default=[1, 10, 20, 30, 40, 60, 80, 100, 150, 200, 400],
     )
     args = parser.parse_args()
-    
+
     #import from config
     config_dict = fu.import_yaml(args.config)
     print('Config File Found')
     print(config_dict)
-    
+
     #override from the command line
     if args.backend is not None:
         backends = [args.backend]
     else:
-        backends = config_dict[args.backend_group]  
+        backends = config_dict[args.backend_group]
     if args.hgp is not None:
         hgp = args.hgp
     else:
-        hgp = config_dict['hgp']   
-    # set default values unless otherwise instructed on config_dict 
+        hgp = config_dict['hgp']
+    # set default values unless otherwise instructed on config_dict
     if 'nseeds' in config_dict.keys():
         nseeds = config_dict['nseeds']
     else:
-        nseeds = args.nseeds   
+        nseeds = args.nseeds
     if 'seed' in config_dict.keys():
         seed = config_dict['seed']
     else:
-        seed = args.seed   
+        seed = args.seed
     if 'cliff_lengths' in config_dict.keys():
         cliff_lengths = config_dict['cliff_lengths']
     else:
-        cliff_lengths = args.cliff_lengths   
+        cliff_lengths = args.cliff_lengths
     if 'nshots' in config_dict.keys():
         nshots = config_dict['nshots']
     else:
@@ -166,7 +166,7 @@ if __name__ == '__main__':
         act_name = config_dict['act_name']
     else:
         act_name = args.name
-    
+
     # Run fast layer fidelity on the list of backends
     print('Running fast layer fidelity on backend(s)')
     run_fast_lf(backends, nseeds, seed, cliff_lengths, nshots, act_name, hgp)

--- a/qiskit_device_benchmarking/verification/gen_circuits.py
+++ b/qiskit_device_benchmarking/verification/gen_circuits.py
@@ -20,9 +20,9 @@ from qiskit import qpy
 from  qiskit_device_benchmarking.bench_code.mrb import MirrorQuantumVolume
 
 def gen_bench_circuits(depths, he, output, opt_level, ntrials, twoqgate):
-    
+
     """ Pregenerate and transpile circuits for fast_bench
-    Will generate the circuits as identity mirrors. Pauli's at 
+    Will generate the circuits as identity mirrors. Pauli's at
     front and back added when running
 
     Args:
@@ -36,23 +36,23 @@ def gen_bench_circuits(depths, he, output, opt_level, ntrials, twoqgate):
     Returns:
         None
     """
-    
+
     print(depths)
     print(he)
     print(output)
     print(opt_level)
     print(ntrials)
     print(twoqgate)
-    
-    
+
+
     for depth in depths:
 
         print('Generating Depth %d Circuits'%(depth))
-        
-        
-        
+
+
+
         #Construct mirror QV circuits on each parallel set
-            
+
         #generate the circuits
         mqv_exp = MirrorQuantumVolume(qubits=list(range(depth)), trials=ntrials,
                               split_inverse=True,pauli_randomize=False,
@@ -60,17 +60,17 @@ def gen_bench_circuits(depths, he, output, opt_level, ntrials, twoqgate):
                              he = he)
 
 
-        
+
         #Do this so it won't compile outside the qubit sets
         cust_map = [[i,i+1] for i in range(depth-1)]
-        
+
         cust_target = Target.from_configuration(basis_gates = ['rz','sx','x','id',twoqgate],
                                                num_qubits=depth,
                                                coupling_map=CouplingMap(cust_map))
-        
+
         mqv_exp.set_transpile_options(target=cust_target, optimization_level=opt_level)
         circs = mqv_exp._transpiled_circuits()
-        
+
         ngates = 0
         ngates_sing = 0
         for circ in circs:
@@ -79,31 +79,31 @@ def gen_bench_circuits(depths, he, output, opt_level, ntrials, twoqgate):
             for i in gate_count:
                 if i!=twoqgate and i!='rz':
                     ngates_sing += gate_count[i]
-            
-            
+
+
         print('Total number of 2Q gates per circuit average: %f'%(ngates/len(circs)))
         print('Total number of 1Q gates (no RZ) per circuit average: %f'%(ngates_sing/len(circs)))
-            
+
         with open('%s_%d.qpy'%(output,depth), 'wb') as fd:
             qpy.dump(circs, fd)
-        
-        
-        
-   
+
+
+
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description = 'Generate circuits'
                                      + 'for fast benchmark and save to qpy'
                                      + ' optimized on a line')
-    parser.add_argument('-d', '--depths', help='depths to generate as a list') 
+    parser.add_argument('-d', '--depths', help='depths to generate as a list')
     parser.add_argument('--he', help='Hardware efficient', action='store_true')
     parser.add_argument('-o', '--output', help='Output filename')
     parser.add_argument('-ol', '--opt_level', help='Optimization Level', default=3)
     parser.add_argument('-n', '--ntrials', help='Number of circuits', default=10)
     parser.add_argument('-g', '--twoqgate', help='Two qubit gate', default='cz')
     args = parser.parse_args()
-    
-    
-    gen_bench_circuits([int(i) for i in args.depths.split(',')], args.he, 
-                   args.output, int(args.opt_level), 
+
+
+    gen_bench_circuits([int(i) for i in args.depths.split(',')], args.he,
+                   args.output, int(args.opt_level),
                    int(args.ntrials), args.twoqgate)


### PR DESCRIPTION
* Correct a few spelling mistakes
* Remove trailing whitespace from lines (my code editors highlights these in yellow)
* Format the README for CLOPS. There were some indents that had no effect on rendering. Also, in the README, all sections had an intro sentence. One of them was not separated by a new line when rendered, although I think this was the intention.