### PR TITLE
Fix: update service authentication code in README (#70)

### DIFF
--- a/qiskit_device_benchmarking/clops/README.md
+++ b/qiskit_device_benchmarking/clops/README.md
@@ -23,8 +23,7 @@ on some of our devices.
 from qiskit_ibm_runtime import QiskitRuntimeService
 from qiskit_device_benchmarking.clops.clops_benchmark import clops_benchmark
 
-service = QiskitRuntimeService(channel="ibm_quantum",
-                               instance="your-hub/group/project")
+service = QiskitRuntimeService()
 
 # Run clops with default settings (twirled circuits, 1000 circuits in run,
 # 100 wide by 100 layers, etc)  Note this is done in a session and currently


### PR DESCRIPTION
This PR addresses issue  #70  by updating the authentication example in the README.

The previous code block for `QiskitRuntimeService` used deprecated parameters. 
As suggested in the issue, this change updates the example to use the current recommended form:

    service = QiskitRuntimeService()

This ensures that new users following the documentation do not encounter deprecated usage warnings and provides a more convenient example.

Closes #70
