### PR TITLE
Update purrb_analysis.py to have `_pur` in analysis result names. 

### DIFF
--- a/qiskit_device_benchmarking/bench_code/prb/purrb_analysis.py
+++ b/qiskit_device_benchmarking/bench_code/prb/purrb_analysis.py
@@ -169,7 +169,7 @@ class PurityRBAnalysis(RBAnalysis):
 
         outcomes.append(
             AnalysisResultData(
-                name="EPC",
+                name="EPC_pur",
                 value=epc,
                 chisq=fit_data.reduced_chisq,
                 quality=quality,
@@ -187,7 +187,7 @@ class PurityRBAnalysis(RBAnalysis):
             )
             outcomes.append(
                 AnalysisResultData(
-                    name="EPC_corrected",
+                    name="EPC_pur_corrected",
                     value=epc,
                     chisq=fit_data.reduced_chisq,
                     quality=quality,
@@ -207,7 +207,7 @@ class PurityRBAnalysis(RBAnalysis):
                 for gate, epg_val in epg_dict.items():
                     outcomes.append(
                         AnalysisResultData(
-                            name=f"EPG_{gate}",
+                            name=f"EPG_pur_{gate}",
                             value=epg_val,
                             chisq=fit_data.reduced_chisq,
                             quality=quality,


### PR DESCRIPTION
Making this change to allow for easier bookkeeping in cases where multiple types of RB experiment are run in the same set of experiments. 