### PR TITLE
Update required qiskit-experiments version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.17
 scipy>=1.4
 qiskit>=1.0
-qiskit-experiments>=0.6
+qiskit-experiments>=0.12
 qiskit-ibm-runtime>=0.28
 matplotlib>=3.4
 rustworkx


### PR DESCRIPTION
`qiskit-experiments` 0.12 was first version that [removed](https://github.com/qiskit-community/qiskit-experiments/pull/1587) hub/group/project access syntax. Using any version older than that would raise an error `QiskitError: 'hgp can be only given in a <hub>/<group>/<project> format'`.  