### PR TITLE
Pin ruff to 0.15.22

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff
+          pip install 'ruff==0.15.22'
       # Update output format to enable automatic inline annotations.
       - name: Run Ruff
         run: ruff check --output-format=github .


### PR DESCRIPTION
Ruff 0.16.0 enables a lot of additional rules by default ([link](https://github.com/astral-sh/ruff/releases/tag/0.16.0)). This PR pins the version of ruff to 0.15.22 to ensure that CI continues to work as intended.

Some of the errors that appear in the new version are valuable, for instance:
```
EXE001 Shebang is present but file is not executable
 --> qiskit_device_benchmarking/verification/fast_layer_fidelity.py:1:1
  |
1 | #!/usr/bin/env python
  | ^^^^^^^^^^^^^^^^^^^^^
2 | # This code is part of Qiskit.
3 | #
```
so it may be valuable to update this pin in the future.